### PR TITLE
Change time calc for time_to_station to use UTC

### DIFF
--- a/custom_components/london_tfl/tfl_data.py
+++ b/custom_components/london_tfl/tfl_data.py
@@ -14,7 +14,7 @@ def get_destination(entry):
 def time_to_station(entry, with_destination=True, style='{0}m {1}s'):
     next_departure_time = (
         parser.parse(entry['expectedArrival']).replace(tzinfo=None) -
-        datetime.now().replace(tzinfo=None)
+        datetime.utcnow().replace(tzinfo=None)
     ).seconds
     next_departure_dest = get_destination(entry)
     return style.format(


### PR DESCRIPTION
Since the data provided by TFL is using UTC for date time, I have updated the time calculation to use utcnow() instead of just now().
Tested on my local installation and resolves time calculation issues when in DST.