### PR TITLE
Fix time_to_station for departed trains

### DIFF
--- a/custom_components/london_tfl/tfl_data.py
+++ b/custom_components/london_tfl/tfl_data.py
@@ -15,7 +15,7 @@ def time_to_station(entry, with_destination=True, style='{0}m {1}s'):
     next_departure_time = (
         parser.parse(entry['expectedArrival']).replace(tzinfo=None) -
         datetime.utcnow().replace(tzinfo=None)
-    ).seconds
+    ).total_seconds()
     next_departure_dest = get_destination(entry)
     return style.format(
         int(next_departure_time / 60),


### PR DESCRIPTION
API sometimes returns trains that have already departed. In this case timedelta between departure time and now() is negative and as a result timedelta.seconds is ~84600 (full day) Usage of `total_seconds()` fixes this issue because it returns the correct (negative) number of seconds