### PR TITLE
[untested] added HASL departure card compatibility layer

### DIFF
--- a/custom_components/london_tfl/hasl_utils.py
+++ b/custom_components/london_tfl/hasl_utils.py
@@ -1,0 +1,66 @@
+from enum import StrEnum
+from typing import TypedDict
+
+
+class TransportType(StrEnum):
+    METRO = "METRO"
+    BUS = "BUS"
+    TRAM = "TRAM"
+    TRAIN = "TRAIN"
+    SHIP = "SHIP"
+    FERRY = "FERRY"
+    TAXI = "TAXI"
+
+
+class DepartureDeviation(TypedDict):
+    importance_level: int
+    consequence: str
+    message: str
+
+
+class DepartureLine(TypedDict):
+    # id: int
+    designation: str
+    transport_mode: TransportType
+    group_of_lines: str
+
+
+class Departure(TypedDict):
+    destination: str
+    deviations: list[DepartureDeviation] | None
+    # direction: str
+    direction_code: int
+    # state: str
+    # display: str
+    # stop_point: dict
+    line: DepartureLine
+    # scheduled: str
+    expected: str
+
+
+def as_hasl_departures(departures: list[dict]) -> list[Departure]:
+    """
+    converts the list of departures into a format
+    that HASL Departure card (3.2.0+) can understand
+
+    the format can be found [here](https://github.com/hasl-sensor/lovelace-hasl-departure-card/blob/master/src/models.ts)
+    """
+
+    return [
+        {
+            "destination": dep["destination"],
+            "deviations": None,
+            "direction_code": 0,
+            "line": {
+                "designation": dep["line"],
+                "transport_mode": (
+                    TransportType.METRO
+                    if dep["type"] == "Metros"
+                    else TransportType.BUS
+                ),
+                "group_of_lines": "",
+            },
+            "expected": dep["expected"],
+        }
+        for dep in departures
+    ]

--- a/custom_components/london_tfl/sensor.py
+++ b/custom_components/london_tfl/sensor.py
@@ -22,6 +22,7 @@ from .const import (
 )
 from .network import request
 from .tfl_data import TfLData
+from .hasl_utils import as_hasl_departures
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -206,10 +207,12 @@ class LondonTfLSensor(SensorEntity):
         if self._tfl_data.is_empty():
             return attributes
 
-        attributes['departures'] = (
-            self._tfl_data.get_departures() if self.is_not_bus()
+        departures = (
+            self._tfl_data.get_departures()
+            if self.is_not_bus()
             else self._tfl_data.get_bus_departures()
         )
+        attributes['departures'] = as_hasl_departures(departures)
 
         data = [
             {
@@ -222,10 +225,7 @@ class LondonTfLSensor(SensorEntity):
             }
         ]
 
-        for index, departure in enumerate(
-            self._tfl_data.get_departures() if self.is_not_bus()
-            else self._tfl_data.get_bus_departures()
-        ):
+        for index, departure in enumerate(departures):
             data.append({
                 'title': departure['destination'],
                 'airdate': departure['expected'],


### PR DESCRIPTION
⚠️ I have not tested this integration AT ALL. Please do so before merging 🙏 


# What
Transform "departures" into a format compatible with the HASL Departure card, so that the line or platform is displayed correctly in HASL Departure card v3.2.0+

# Why
https://github.com/morosanmihail/HA-LondonTfL/issues/36
https://github.com/hasl-sensor/lovelace-hasl-departure-card/issues/44

# How
Add a translation layer in the form of `hasl_utils.as_as_hasl_departures` function and a set of guidance types.
