### PR TITLE
feat: add arrivals for thameslink

### DIFF
--- a/custom_components/london_tfl/const.py
+++ b/custom_components/london_tfl/const.py
@@ -23,7 +23,8 @@ LINE_IMAGES = {
 
 TFL_LINES_URL = 'https://api.tfl.gov.uk/line/mode/{0}'
 TFL_ARRIVALS_URL = 'https://api.tfl.gov.uk/line/{0}/arrivals/{1}?test={2}'
-TFL_BUS_ARRIVALS_URL = 'https://api.tfl.gov.uk/StopPoint/{0}/arrivals/?test={1}'
+TFL_ALT_ARRIVALS_URL = 'https://api.tfl.gov.uk/StopPoint/{1}/arrivaldepartures/?lineIds={0}&test={2}'
+TFL_BUS_ARRIVALS_URL = 'https://api.tfl.gov.uk/StopPoint/{1}/arrivals/?test={2}'
 TFL_STATIONS_URL = 'https://api.tfl.gov.uk/line/{0}/stoppoints'
 
 SHORTEN_STATION_NAMES = ['Underground Station', 'DLR Station']

--- a/custom_components/london_tfl/tfl_data.py
+++ b/custom_components/london_tfl/tfl_data.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from dateutil import parser
 
+from custom_components.london_tfl.const import TFL_ALT_ARRIVALS_URL, TFL_ARRIVALS_URL, TFL_BUS_ARRIVALS_URL
+
 
 def get_destination(entry, use_destination_name=False):
     if use_destination_name and 'destinationName' in entry:
@@ -12,9 +14,9 @@ def get_destination(entry, use_destination_name=False):
     return ''
 
 
-def time_to_station(entry, with_destination=True, style='{0}m {1}s'):
+def time_to_station(entry, arrival, with_destination=True, style='{0}m {1}s'):
     next_departure_time = (
-        parser.parse(entry['expectedArrival']).replace(tzinfo=None) -
+        parser.parse(arrival).replace(tzinfo=None) -
         datetime.utcnow().replace(tzinfo=None)
     ).total_seconds()
     next_departure_dest = get_destination(entry, True)
@@ -25,11 +27,13 @@ def time_to_station(entry, with_destination=True, style='{0}m {1}s'):
 
 
 class TfLData:
-    def __init__(self):
+    def __init__(self, *, method: str, line: str):
         self._raw_result = []
         self._last_update = None
         self._api_json = []
         self._station_name = ""
+        self.method = method
+        self.line = line
 
     def populate(self, json_data, filter_platform):
         self._raw_result = json_data
@@ -44,7 +48,7 @@ class TfLData:
             try:
                 after_now = [
                     item for item in self._raw_result
-                    if parser.parse(item['expectedArrival']).timestamp() > now
+                    if parser.parse(self._get_expected_arrival(item)).timestamp() > now
                 ]
             except Exception:
                 after_now = []
@@ -58,67 +62,88 @@ class TfLData:
         if filter_platform != '':
             self._raw_result = [
                 item for item in self._raw_result
-                if ('platformName' in item and filter_platform in item['platformName']) or ('lineName' in item and filter_platform in item['lineName'])
+                if filter_platform in self._get_platform_name(item)
             ]
 
     def sort_data(self, max_items):
         self._api_json = sorted(
-            self._raw_result, key=lambda i: i['expectedArrival'], reverse=False
+            self._raw_result, key=self._get_expected_arrival, reverse=False
         )[:max_items]
 
     def get_state(self):
         if len(self._api_json) > 0:
             return parser.parse(
-                self._api_json[0]['expectedArrival']
+              self._get_expected_arrival(self._api_json[0])
             ).strftime('%H:%M')
         return 'None'
 
     def is_empty(self):
         return len(self._api_json) == 0
 
+    def _is_not_bus(self) -> bool:
+        return (self.method != 'bus')
+
+    def _is_alt_api(self) -> bool:
+        return (self.method == "national-rail" and self.line == "thameslink")
+
+    def _get_expected_departure(self, item) -> str:
+        if self._is_alt_api():
+            return item.get('estimatedTimeOfDeparture', item['scheduledTimeOfDeparture'])
+        return item['expectedArrival']
+
+    def _get_expected_arrival(self, item) -> str:
+        if self._is_alt_api():
+            return item.get('estimatedTimeOfArrival', item['scheduledTimeOfArrival'])
+        return item['expectedArrival']
+
+    def _get_platform_name(self, item) -> str:
+        platform_prop = 'platformName' if self._is_not_bus() else 'lineName'
+        return item.get(platform_prop, '')
+
+    def url(self, *, station: str, test: str = '') -> str: 
+        if self._is_not_bus():
+            if self._is_alt_api():
+              template = TFL_ALT_ARRIVALS_URL
+            else:
+              template = TFL_ARRIVALS_URL
+        else:
+            template = TFL_BUS_ARRIVALS_URL
+
+        return template.format(
+            self.line,
+            station,
+            test
+        )
+
     def get_departures(self):
         departures = []
         for item in self._api_json:
+            icon = 'mdi:train'
+            type = None
+            if self._is_not_bus():
+              if self._is_alt_api():
+                type = 'Trains'
+              else:
+                type = 'Metros'
+            else:
+              type = 'Buses'
+              icon = 'mdi:bus'
+
+            expected_departure = self._get_expected_departure(item)
+            expected_arrival = self._get_expected_arrival(item)
+            platform = self._get_platform_name(item)
             departure = {
-                'time_to_station': time_to_station(item, False),
-                'platform': (
-                    item['platformName'] if 'platformName' in item else ''
-                ),
-                'line': item['platformName'] if 'platformName' in item else '',
+                'time_to_station': time_to_station(item, expected_arrival, False),
+                'platform': platform,
+                'line': platform,
                 'direction': 0,
-                'departure': item['expectedArrival'],
+                'departure': expected_departure,
                 'destination': get_destination(item, False),
-                'time': time_to_station(item, False, '{0}'),
-                'expected': item['expectedArrival'],
-                'type': 'Metros',
+                'time': time_to_station(item, expected_departure, False, '{0}'),
+                'expected': expected_arrival,
+                'type': type,
                 'groupofline': '',
-                'icon': 'mdi:train',
-            }
-
-            departures.append(departure)
-
-            if len(self._station_name) == 0:
-                self._station_name = item['stationName']
-
-        return departures
-
-    def get_bus_departures(self):
-        departures = []
-        for item in self._api_json:
-            departure = {
-                'time_to_station': time_to_station(item, False),
-                'platform': (
-                    item['lineName'] if 'lineName' in item else ''
-                ),
-                'line': item['lineName'] if 'lineName' in item else '',
-                'direction': 0,
-                'departure': item['expectedArrival'],
-                'destination': get_destination(item, True),
-                'time': time_to_station(item, False, '{0}'),
-                'expected': item['expectedArrival'],
-                'type': 'Buses',
-                'groupofline': '',
-                'icon': 'mdi:bus',
+                'icon': icon,
             }
 
             departures.append(departure)


### PR DESCRIPTION
Partial fix for #31

This PR implements the solution proposed [here](https://github.com/morosanmihail/HA-LondonTfL/issues/31#issuecomment-2266642252) to show departures for Thameslink trains.

As knowledge of the shape of the data is important for many functions of `TflData` (e.g. `sort_data` or `get_state`), the decision of which URL to use and how to parse the data was completely moved from `LondonTfLSensor` to `TflData`. This allow for more flexibility if similar cases where to happen in the future (e.g. if another API for Southeastern were to be added).