### PR TITLE
fix: correctly catch errors from ArrivalDepartures for some national-rail lines

### DIFF
--- a/custom_components/london_tfl/sensor.py
+++ b/custom_components/london_tfl/sensor.py
@@ -186,6 +186,10 @@ class LondonTfLSensor(SensorEntity):
                     self._state = "Cannot reach TfL"
                     return
                 result = json.loads(result)
+                if isinstance(result, str):
+                    _LOGGER.warning("TfL API error: %s", result)
+                    self._state = "Invalid reply from TfL"
+                    return
             except OSError:
                 _LOGGER.warning("Something broke.")
                 self._state = "Cannot reach TfL"


### PR DESCRIPTION
Recently, I have been seeing this error in my logs:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 807, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1314, in async_device_update
    await self.async_update()
  File "/config/custom_components/london_tfl/sensor.py", line 199, in async_update
    self._tfl_data.sort_data(self.max_items)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/config/custom_components/london_tfl/tfl_data.py", line 76, in sort_data
    self._api_json = sorted(
                     ~~~~~~^
        self._raw_result, key=self._get_expected_arrival, reverse=False
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )[:max_items]
    ^
  File "/config/custom_components/london_tfl/tfl_data.py", line 101, in _get_expected_arrival
    return item.get(TFL_TRANSPORT_TYPES[method]["expected_arrival"], "")
           ^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
```

Turns out that the ArrivalDepartures endpoint (https://api.tfl.gov.uk/StopPoint/XYZ/ArrivalDepartures\?lineIds\=LINE) started returning `line id LINE is invalid` instead of a JSON object. This seems to only affect non-Thameslink trains (which makes sense as it's the only one supported on that endpoint).

This PR just catches the error and logs it.

I am also working to a bigger fix so we can get departures times for other National Rail services outside Thameslink (I would really like to have the South Eastern trains stopping at my local station 😬). Unfortunately, this will need to rely on [OpenLDBWS](https://lite.realtime.nationalrail.co.uk/OpenLDBWS/) and thus require an extra API token which the user must create and provide but there doesn't seem to be any other alternative?